### PR TITLE
Show Error reasons when bulk fails

### DIFF
--- a/indexing.go
+++ b/indexing.go
@@ -32,7 +32,7 @@ type Options struct {
 
 // Item represents a bulk action.
 type Item struct {
-	IndexAction struct {
+	Create struct {
 		Index  string `json:"_index"`
 		Type   string `json:"_type"`
 		ID     string `json:"_id"`
@@ -41,7 +41,7 @@ type Item struct {
 			Type   string `json:"type"`
 			Reason string `json:"reason"`
 		} `json:"error"`
-	}
+	} `json:"create"`
 }
 
 // BulkResponse is a response to a bulk request.
@@ -179,7 +179,12 @@ func BulkIndex(docs []string, options Options) error {
 		return err
 	}
 	if br.HasErrors {
-		return fmt.Errorf("error during bulk operation, try less workers (lower -w value) or increase thread_pool.bulk.queue_size in your nodes")
+		// Gather Error reasons
+		var errors []string
+		for _, item := range br.Items {
+			errors = append(errors, item.Create.Error.Reason)
+		}
+		return fmt.Errorf("error during bulk operation, try less workers (lower -w value) or increase thread_pool.bulk.queue_size in your nodes or check error on server. Errors: %s", errors)
 	}
 	return nil
 }


### PR DESCRIPTION
The current version is misleading when it comes to reporting errors. For ex, if I try to push a malformed json, it reports this error:-

```
$ ./esbulk  -index rum-hello -server http://vimehta-ld1:9200  -w 1 docs  
2017/06/06 04:13:45 error during bulk operation, try less workers (lower -w value) or increase thread_pool.bulk.queue_size in your nodes
$ 
```
Now, a new user will be confused seeing this error and will think that it's actually due to finishing up bulk threads at Elasticsearch side. This PR makes the error a little more informant. 

```
% ./esbulk -index test_index -server http://arastogi-ld1:9200/ ~/docs.json
2017/06/06 05:59:05 error during bulk operation, try less workers (lower -w value) or increase thread_pool.bulk.queue_size in your nodes or check error on server. Errors: [failed to parse]
%
```

What do you think? Is there a better way to show errors?