### PR TITLE
Fixes for multi-server support and x-pack

### DIFF
--- a/administration.go
+++ b/administration.go
@@ -1,0 +1,78 @@
+package esbulk
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func FlushIndex(idx int, options Options) error {
+	server := options.Servers[idx]
+	link := fmt.Sprintf("%s/%s/_flush", server, options.Index)
+	req, err := http.NewRequest("POST", link, nil)
+	if err != nil {
+		return err
+	}
+	if options.Username != "" && options.Password != "" {
+		req.SetBasicAuth(options.Username, options.Password)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if options.Verbose {
+		log.Printf("index flushed: %s\n", resp.Status)
+	}
+	return nil
+}
+
+// getSettingsRequest fetches the settings of the index.
+func GetSettings(idx int, options Options) (map[string]interface{}, error) {
+	server := options.Servers[idx]
+	link := fmt.Sprintf("%s/%s/_settings", server, options.Index)
+
+	req, err := http.NewRequest("GET", link, nil)
+	if err != nil {
+		return nil, err
+	}
+	if options.Username != "" && options.Password != "" {
+		req.SetBasicAuth(options.Username, options.Password)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("could not get settings: %s", link)
+	}
+
+	doc := make(map[string]interface{})
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("failed to decode settings: %v", err)
+	}
+	// Example response.
+	// {
+	// 	"ai": {
+	// 	  "settings": {
+	// 		"index": {
+	// 		  "refresh_interval": "1s",
+	// 		  "number_of_shards": "5",
+	// 		  "provided_name": "ai",
+	// 		  "creation_date": "1523372145102",
+	// 		  "number_of_replicas": "1",
+	// 		  "uuid": "5k-id0OZTKKU4A7DeeUNdQ",
+	// 		  "version": {
+	// 			"created": "6020399"
+	// 		  }
+	// 		}
+	// 	  }
+	// 	}
+	// }
+
+	return doc, nil
+}

--- a/indexing.go
+++ b/indexing.go
@@ -136,7 +136,7 @@ func BulkIndex(docs []string, options Options) error {
 			dec := json.NewDecoder(strings.NewReader(doc))
 			dec.UseNumber()
 			if err := dec.Decode(&docmap); err != nil {
-				return err
+				return fmt.Errorf("failed to json decode doc: %v", err)
 			}
 
 			idstring := options.IDField //A delimiter separates string with all the fields to be used as ID


### PR DESCRIPTION
First of all, thanks for sharing and maintaining an awesome project 👍 

A series of changes included in this PR was necessary for me to successfully index any doc.

- Make `GET /_settings` to work against X-pack protected ES (Prior to this commit, there was no auth header provided while calling this API!
- Make `POST /_flush` and `GET /_settings` to be multi-server aware (esbulk recently deprecated host/port and migrated to `-server` option. As far as I can see, these two were not supporting the option at all. Instead, they were expecting -host/-port and completely ignoring `-server` options. )