### PR TITLE
Update run.go

### DIFF
--- a/run.go
+++ b/run.go
@@ -44,7 +44,7 @@ import (
 
 var (
 	// Version of application.
-	Version = "0.7.31"
+	Version = "0.7.32"
 
 	ErrIndexNameRequired = errors.New("index name required")
 	ErrNoWorkers         = errors.New("no workers configured")


### PR DESCRIPTION
Raise version number, as "-v" shows 31 for version 32... re-creating the tag would not help for existing installations so maybe create a new tag?